### PR TITLE
Add region option

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,14 @@ emrss \
     --s3-bucket $S3_BUCKET \
     -f notebook.ipynb
 ```
+
+If you don't have a default region set in your config or environment, you can use the `--region` parameter:
+
+```bash
+emrss \
+    --application-id $APPLICATION_ID \
+    --job-role-arn $JOB_ROLE_ARN \
+    --s3-bucket $S3_BUCKET \
+    --region $REGION \
+    "show tables"
+```

--- a/emr_serverless_sql/emr_serverless.py
+++ b/emr_serverless_sql/emr_serverless.py
@@ -6,16 +6,17 @@ from string import Template
 
 import boto3
 from botocore.exceptions import ClientError
+from botocore.config import Config
 
 from emr_serverless_sql import console_log
 
 
 class Session:
-    def __init__(self, application_id, job_role, s3_bucket):
+    def __init__(self, application_id, job_role, s3_bucket, region):
         self.application_id = application_id
         self.job_role = job_role
         self.s3_bucket = s3_bucket
-        self.client = boto3.client("emr-serverless")
+        self.client = boto3.client("emr-serverless", config=Config(region_name=region))
         self.s3_client = boto3.client("s3")
 
     def start_application(self):

--- a/emr_serverless_sql/emrss_cli.py
+++ b/emr_serverless_sql/emrss_cli.py
@@ -7,6 +7,7 @@ from .emr_serverless import Session
 @click.option("--application-id", default=None, help="Application ID", required=True)
 @click.option("--job-role-arn", default=None, help="Job Role ARN", required=True)
 @click.option("--s3-bucket", default=None, help="S3 bucket", required=True)
+@click.option("--region", default=None, help="Region", required=False)
 @click.option(
     "--file",
     "-f",
@@ -15,14 +16,14 @@ from .emr_serverless import Session
     type=click.Path(exists=True, dir_okay=False),
 )
 @click.argument("sql_statement", required=False)
-def run(application_id, job_role_arn, s3_bucket, sql_statement, file):
+def run(application_id, job_role_arn, s3_bucket, region, sql_statement, file):
     if file and sql_statement:
         raise click.UsageError("Cannot use --file and query string at the same time.")
     if not file and not sql_statement:
         raise click.UsageError("Must specify either --file or query string.")
     if file and (not file.endswith(".sql") and not file.endswith(".ipynb")):
         raise click.UsageError("File must be a .sql or .ipynb file.")
-    session = Session(application_id, job_role_arn, s3_bucket)
+    session = Session(application_id, job_role_arn, s3_bucket, region)
     session.start_application()
     jobrunid: str
     if sql_statement:


### PR DESCRIPTION
You can set the region with `AWS_DEFAULT_REGION`, but sometimes you want to be able to do it with a command line option too.